### PR TITLE
apply sbt scalaVersion to all projects in build.

### DIFF
--- a/frontend/src/main/scala/zip/JSZip.scala
+++ b/frontend/src/main/scala/zip/JSZip.scala
@@ -176,7 +176,7 @@ organization := "$group"
 name := "$artifact"
 description := "A very special project generated with zio-start. Good luck!"
 version := "0.1.0"
-scalaVersion := "2.13.8"
+ThisBuild/scalaVersion := "2.13.8"
 
 val zioVersion = "${Dependency.zioVersion}"
 


### PR DESCRIPTION
It seems `scalaVersion` without `ThisBuild/` in front only applies to the root project. 🤷🏻